### PR TITLE
Support containerless rehydration

### DIFF
--- a/src/__tests__/__snapshots__/tests.ts.snap
+++ b/src/__tests__/__snapshots__/tests.ts.snap
@@ -1,26 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reactFromMarkupContainer E2E tests Should rehydrate a basic component 1`] = `
-"
-      <div data-react-from-html-container=\\"\\">
-        <span>rehydrated component</span>
-      </div>"
-`;
+exports[`reactFromHtml E2E tests Should rehydrate a basic component 1`] = `"<div class=\\"rehydration-root\\"><span>rehydrated component</span></div>"`;
 
-exports[`reactFromMarkupContainer E2E tests Should rehydrate valid HTML markup 1`] = `
+exports[`reactFromHtml E2E tests Should work for nested rehydratables 1`] = `
 "
-    <div data-react-from-html-container=\\"\\">
-      <p>paragraph</p>
-    </div>"
-`;
-
-exports[`reactFromMarkupContainer E2E tests Should work for nested markup containers 1`] = `
-"
-      <div data-react-from-html-container=\\"\\">
-        <span>rehydrated component</span>
-          <div data-react-from-html-container=\\"\\">
-            <span>rehydrated component</span>
-            <span>rehydrated component</span>
-          </div>
-      </div>"
+      <div class=\\"rehydration-root\\"><span>
+        <div class=\\"rehydration-root\\"><span>
+          Hello, World!
+        </span></div>
+      </span></div>
+      "
 `;

--- a/src/rehydrator.ts
+++ b/src/rehydrator.ts
@@ -23,7 +23,8 @@ const rehydratableToReactElement = async (
 
   return rehydrator(
     el,
-    children => rehydrateChildren(children, rehydrators, options),
+    async children =>
+      (await rehydrateChildren(children, rehydrators, options)).rehydrated,
     options.extra
   );
 };
@@ -44,11 +45,34 @@ const createCustomHandler = (
   return false;
 };
 
-const rehydrateChildren = (
+const createReactRoot = (el: Node) => {
+  const container = document.createElement("div");
+
+  if (el.parentNode) {
+    el.parentNode.replaceChild(container, el);
+  }
+
+  container.appendChild(el);
+  container.classList.add("rehydration-root");
+
+  return container;
+};
+
+const rehydrateChildren = async (
   el: Node,
   rehydrators: IRehydrator,
   options: IOptions
-) => domElementToReact(el, createCustomHandler(rehydrators, options));
+) => {
+  const container = createReactRoot(el);
+
+  return {
+    container,
+    rehydrated: await domElementToReact(
+      container,
+      createCustomHandler(rehydrators, options)
+    ),
+  };
+};
 
 const render = ({
   rehydrated,
@@ -67,14 +91,23 @@ const render = ({
   ReactDOM.render(rehydrated as React.ReactElement<any>, root);
 };
 
+const createQuerySelector = (rehydratableIds: string[]) =>
+  rehydratableIds.reduce(
+    (acc: string, rehydratableId: string) =>
+      `${acc ? `${acc}, ` : ""}[data-rehydratable*="${rehydratableId}"]`,
+    ""
+  );
+
 export default async (
   container: Element,
   rehydrators: IRehydrator,
   options: IOptions
 ) => {
+  const selector = createQuerySelector(Object.keys(rehydrators));
+
   const roots = Array.from(
     // TODO: allow setting a container identifier so multiple rehydration instances can exist
-    container.querySelectorAll("[data-react-from-html-container]")
+    container.querySelectorAll(selector)
   ).reduce((acc: Element[], root: Element) => {
     // filter roots that are contained within other roots
     if (!acc.some(r => r.contains(root))) {
@@ -92,13 +125,12 @@ export default async (
     if (container.contains(root)) {
       renders.push(async () => {
         try {
-          const rehydrated = await rehydrateChildren(
-            root,
-            rehydrators,
-            options
-          );
+          const {
+            container: rootContainer,
+            rehydrated,
+          } = await rehydrateChildren(root, rehydrators, options);
 
-          return { root, rehydrated };
+          return { root: rootContainer, rehydrated };
         } catch (e) {
           /* tslint:disable-next-line no-console */
           console.error("Rehydration failure", e);


### PR DESCRIPTION
Description copied from https://github.com/simon360/react-from-markup/pull/48.

## What?

Implements support for containerless rehydration. Instead of

```html
<html>
  <body>
    <div data-react-from-markup-container>
      <div class="Clock" data-rehydratable="Clock">
        15:21:11
      </div>
    </div>
  </body>
</html>
```

You can now have

```html
<html>
  <body>
    <div class="Clock" data-rehydratable="Clock">
      15:21:11
    </div>
  </body>
</html>
```

## How?

It does this by:

1. Using the keys from the `rehydrators` object to query select all `data-rehydratable` tags
2. Wrapping the root of that rehydratable in another element
3. Using the new container as the React root

## Breaking changes

It also introduces two breaking changes:
1. `rehydrateChildren` now returns an object containing `container` and `rehydrated`
2. `data-rehydratable` must now match the rehydrator key provided in `rehydrators`

The first of the two will become redundant in my following PR, where I will change how rehydrateChildren behaves entirely.
