### PR TITLE
refactor: rename rehydrators to hydrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,38 +41,38 @@ const ShowMore = ({ content }) => (
 const root = document.querySelector("body");
 
 reactFromHTML(root, {
-  // Map all `.ShowMore` elements using a rehydrator function
+  // Map all `.ShowMore` elements using a hydrator
   ".ShowMore": async el => <ShowMore content={el.dataset.content} />,
 });
 ```
 
 ## API
 
-### `reactFromHTML(root, rehydrators, options)`
+### `reactFromHTML(root, hydrators, options)`
 
 Params:
 
 - **root**: Element - Root element containing your components
-- **rehydrators**: Object - mapping functions
+- **hydrators**: Object - mapping functions
   - **key**: String - The query selector for the component
-  - **value**: Func - A **Rehydrator Function**, describing how to map this element to a React component (see below).
+  - **value**: Func - A **Hydrator Function**, describing how to map this element to a React component (see below).
 - **Options**: Object
-  - **extra**: Object - additional properties passed to each rehydrator functions
+  - **extra**: Object - additional properties passed to each hydrator
   - **getQuerySelector**: (key:String): String - a function for defining custom query selectors for each key
 
-### `rehydrator(el, rehydrate, extra): ReactNode`
+### `hydrator(el, hydrate, extra): ReactNode`
 
 Defined by you for each component you want to convert back into React. It maps an `Element` into a `ReactNode`.
 
 - **el**: Element - the element for this component, as defined by the query selector
-- **rehydrate(el)**: Func - a convenience, prebaked version of `reactFromHTML` used for rehydrating child nodes. For example, converting `innerHTML` into React children.
+- **hydrate(el)**: Func - a convenience, prebaked version of `reactFromHTML` used for hydrating child nodes. For example, converting `innerHTML` into React children.
 - **extra**: Object - additional params as defined in the initial `reactFromHTML()` call.
 
 ## Examples
 
-### Basic rehydration
+### Basic hydration
 
-This example shows rehydration of a basic component, with the single prop `content` that is assigned to a data attribute.
+This example shows hydration of a basic component, with the single prop `content` that is assigned to a data attribute.
 
 #### React
 
@@ -92,7 +92,7 @@ const ShowMore = ({ content }) => (
 </body>
 ```
 
-#### Rehydration
+#### Hydration
 
 ```jsx
 reactFromHTML(document.querySelector("body"), {
@@ -100,9 +100,9 @@ reactFromHTML(document.querySelector("body"), {
 });
 ```
 
-### Advanced rehydration
+### Advanced hydration
 
-This example shows rehydration of a more complex component, with multiple props, and children which may themselves need rehydrating.
+This example shows hydration of a more complex component, with multiple props, and children which may themselves need hydrating.
 
 #### React
 
@@ -136,22 +136,20 @@ const ShowMore = ({ content }) => (
 </body>
 ```
 
-#### Rehydration
+#### Hydration
 
 ```jsx
-const ModalRehydrator = async (el, rehydrate) => (
+const ModalHydrator = async (el, hydrate) => (
   <Modal title={el.querySelector(".Modal-title").innerHTML}>
-    {rehydrate(el.querySelector(".Modal-inner"))}
+    {hydrate(el.querySelector(".Modal-inner"))}
   </Modal>
 );
 
-const ShowMoreRehydrator = async el => (
-  <ShowMore content={el.dataset.content} />
-);
+const ShowMoreHydrator = async el => <ShowMore content={el.dataset.content} />;
 
 reactFromHTML(document.querySelector("body"), {
-  ".Modal": ModalRehydrator,
-  ".ShowMore": ShowMoreRehydrator,
+  ".Modal": ModalHydrator,
+  ".ShowMore": ShowMoreHydrator,
 });
 ```
 

--- a/src/IHydrator.ts
+++ b/src/IHydrator.ts
@@ -1,9 +1,9 @@
 import * as React from "react";
 
-export default interface IRehydrator {
+export default interface IHydrator {
   [name: string]: (
     el: Element,
-    rehydrate: (element: Element) => React.ReactNode,
+    hydrate: (element: Element) => React.ReactNode,
     extra: object
   ) => Promise<React.ReactElement<any>>;
 }

--- a/src/__tests__/__snapshots__/tests.ts.snap
+++ b/src/__tests__/__snapshots__/tests.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reactFromHtml E2E tests Should rehydrate a basic component 1`] = `"<div class=\\"rehydration-root\\"><span>rehydrated component</span></div>"`;
+exports[`reactFromHtml E2E tests Should hydrate a basic component 1`] = `"<div class=\\"hydration-root\\"><span>hydrated component</span></div>"`;
 
-exports[`reactFromHtml E2E tests Should rehydrate components with custom query selectors 1`] = `"<div class=\\"rehydration-root\\"><span>rehydrated component</span></div>"`;
+exports[`reactFromHtml E2E tests Should hydrate components with custom query selectors 1`] = `"<div class=\\"hydration-root\\"><span>hydrated component</span></div>"`;
 
-exports[`reactFromHtml E2E tests Should work for nested rehydratables 1`] = `
+exports[`reactFromHtml E2E tests Should work for nested hydratables 1`] = `
 "
-      <div class=\\"rehydration-root\\"><span>
-        <div class=\\"rehydration-root\\"><span>
+      <div class=\\"hydration-root\\"><span>
+        <div class=\\"hydration-root\\"><span>
           Hello, World!
         </span></div>
       </span></div>

--- a/src/__tests__/tests.ts
+++ b/src/__tests__/tests.ts
@@ -3,34 +3,34 @@ import * as React from "react";
 import reactFromHtml from "..";
 
 describe("reactFromHtml E2E tests", async () => {
-  it("Should rehydrate a basic component", async () => {
+  it("Should hydrate a basic component", async () => {
     const componentName: string = "myComponent";
 
-    const rehydrator = async () => {
-      return React.createElement("span", {}, "rehydrated component");
+    const hydrator = async () => {
+      return React.createElement("span", {}, "hydrated component");
     };
 
-    const rehydrators = { [`.${componentName}`]: rehydrator };
+    const hydrators = { [`.${componentName}`]: hydrator };
     const documentElement = document.createElement("div");
 
     documentElement.innerHTML = `<div class="${componentName}"></div>`;
 
-    await reactFromHtml(documentElement, rehydrators, {
+    await reactFromHtml(documentElement, hydrators, {
       extra: {},
     });
 
     expect(documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it("Should work for nested rehydratables", async () => {
+  it("Should work for nested hydratables", async () => {
     const componentName: string = "mycomponentName";
 
     const mockCall = jest.fn();
-    const rehydrators = {
-      [`.${componentName}`]: async (el, rehydrate) => {
+    const hydrators = {
+      [`.${componentName}`]: async (el, hydrate) => {
         mockCall();
 
-        return React.createElement("span", {}, await rehydrate(el));
+        return React.createElement("span", {}, await hydrate(el));
       },
     };
 
@@ -44,7 +44,7 @@ describe("reactFromHtml E2E tests", async () => {
       </div>
       `;
 
-    await reactFromHtml(documentElement, rehydrators, {
+    await reactFromHtml(documentElement, hydrators, {
       extra: {},
     });
 
@@ -52,21 +52,21 @@ describe("reactFromHtml E2E tests", async () => {
     expect(mockCall).toBeCalledTimes(2);
   });
 
-  it("Should rehydrate components with custom query selectors", async () => {
+  it("Should hydrate components with custom query selectors", async () => {
     const componentName: string = "myComponent";
 
-    const rehydrator = async () => {
-      return React.createElement("span", {}, "rehydrated component");
+    const hydrator = async () => {
+      return React.createElement("span", {}, "hydrated component");
     };
 
-    const rehydrators = { [componentName]: rehydrator };
+    const hydrators = { [componentName]: hydrator };
     const documentElement = document.createElement("div");
 
-    documentElement.innerHTML = `<div data-rehydratable="test-${componentName}"></div>`;
+    documentElement.innerHTML = `<div data-hydratable="test-${componentName}"></div>`;
 
-    await reactFromHtml(documentElement, rehydrators, {
+    await reactFromHtml(documentElement, hydrators, {
       extra: {},
-      getQuerySelector: key => `[data-rehydratable*="${key}"]`,
+      getQuerySelector: key => `[data-hydratable*="${key}"]`,
     });
 
     expect(documentElement.innerHTML).toMatchSnapshot();

--- a/src/dom-element-to-react/specialElementHandlers.ts
+++ b/src/dom-element-to-react/specialElementHandlers.ts
@@ -26,7 +26,7 @@ const specialElementHandlers: ISpecialElementHandlers = {
     }
 
     // Use the DOM element properties instead of attributes. These may reflect
-    // changes the user has already made before we could rehydrate.
+    // changes the user has already made before we could hydrate.
     if ((el as HTMLInputElement).checked) {
       toReturn.defaultChecked = (el as HTMLInputElement).checked;
     }
@@ -59,7 +59,7 @@ const specialElementHandlers: ISpecialElementHandlers = {
     }
 
     // Use the DOM element properties instead of attributes. These may reflect
-    // changes the user has already made before we could rehydrate.
+    // changes the user has already made before we could hydrate.
     if ((el as HTMLSelectElement).value) {
       toReturn.defaultValue = (el as HTMLSelectElement).value;
     }
@@ -76,7 +76,7 @@ const specialElementHandlers: ISpecialElementHandlers = {
     }
 
     // Use the DOM element properties instead of attributes. These may reflect
-    // changes the user has already made before we could rehydrate.
+    // changes the user has already made before we could hydrate.
     if ((el as HTMLTextAreaElement).value) {
       toReturn.defaultValue = (el as HTMLTextAreaElement).value;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./rehydrator";
+export { default } from "./hydrate";


### PR DESCRIPTION
_Re_-hydration suggests the components have been hydrated previously, which they have not.

This PR renames all references to `hydrator` to accurately reflect the function.